### PR TITLE
관련없는 기사 필터링 강화

### DIFF
--- a/scrapers/article_extractor.py
+++ b/scrapers/article_extractor.py
@@ -167,9 +167,9 @@ class ArticleExtractor(BaseSearcher):
                     config=config,
                 )
 
-                if not text or not text.strip():
+                if (not text) or (not text.strip()) or (len(text) < 200):
                     logger.warning(
-                        f"[ArticleExtractor] 본문 추출 실패 - "
+                        f"[ArticleExtractor] 본문이 없습니다 - "
                         f"URL: {url['url']}, 제목을 본문으로 사용"
                     )
                     text = title

--- a/scrapers/serper.py
+++ b/scrapers/serper.py
@@ -86,7 +86,7 @@ def distribute_news_serper(
     current -= timedelta(days=1)
     while current < endAt:
         # 한 날짜의 여러 뉴스 링크
-        max_count = -1
+        max_count = 0
         best_news = None
         seen_links = set()
         current += timedelta(days=1)
@@ -103,6 +103,10 @@ def distribute_news_serper(
             if count > max_count:
                 best_news = (link, title)
                 max_count = count
+
+        # 관련없는 뉴스만 나옴
+        if not best_news:
+            continue
 
         # 최적의 뉴스 result에 추가
         link, title = best_news


### PR DESCRIPTION
### scraper/article_extractor.py
- 기사 본문이 200자 미만이면, 제목을 내용으로 대체
- 같은 사이트 다른 뉴스가 내용으로 나타나는 것을 방지

### scraper/serper.py
- 제목에 검색어가 하나도 없으면 스킵
- 동명이인 기자 문제도 해결 가능